### PR TITLE
How to use a Regular Account (updated w/ master)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-// const { Client, WebhookClient, MessageEmbed, } = require('discord.js-selfbot-v13');
-const { Client, Attachment, MessageEmbed, Message, Intents, WebhookClient } = require('discord.js');
-const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES]});
+const { Client, WebhookClient, MessageEmbed, } = require('discord.js-selfbot-v13');
+const client = new Client();
 const config = require('./config.json');
 
 if(!config.token) return console.log('No token provided.');


### PR DESCRIPTION
If you are not using a bot, your only other option is using a regular account (selfbot).

`discord.js` only allows bot tokens to be connected to the gateway so you are forced to use another package, [discord.js-selfbot-v13](https://github.com/aiko-chan-ai/discord.js-selfbot-v13).

## How to install
npm install discord.js-selfbot-v13@latest
npm uninstall discord.js

## Changes
You will have to change a few things how the classes are destructured and required, replace `discord.js` with `discord.js-selfbot-v13`.

## Code Replacement
Replace the first 2 lines, with this:
```js
const { Client, WebhookClient, MessageEmbed, } = require('discord.js-selfbot-v13');
const client = new Client();
```
> Look at the [Files changed](https://github.com/ignshifts/MessageLogger/pull/3/files) if you need a visual representation.